### PR TITLE
Fixed Class Selector for reverseColor

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -101,7 +101,7 @@ body {
 	--secondary-subscription-background: #000000;
 }
 
-[data-theme="1"].reverseColor {
+[data-theme="1"] .reverseColor {
 	filter: invert(100%) sepia(12%) saturate(3262%) hue-rotate(178deg)
 		brightness(101%) contrast(91%);
 }


### PR DESCRIPTION
# Skiosa - PR
- [ ] added test(s), or explain why one is not needed/possible... (No Integration tests)
- [ ] added comments to all the functions (No new Functions)
- [ ] added documentation to latex project (Not a Story)
- [x] code can't be split up into smaller logical units
- [x] code is formated and linted

Class reverseColor was not working if theme differs from default theme. <- This is fixed by using the right css selektor